### PR TITLE
Debug printf

### DIFF
--- a/krnlc/src/main.rs
+++ b/krnlc/src/main.rs
@@ -652,7 +652,9 @@ crate-type = ["dylib"]
     let mut spirv_module = rspirv::dr::load_bytes(std::fs::read(spirv_path)?)
         .map_err(|e| Error::msg(e.to_string()))?;
     if debug_printf {
-        spirv_module.debug_string_source.retain(|inst| inst.class.opcode == rspirv::spirv::Op::String);
+        spirv_module
+            .debug_string_source
+            .retain(|inst| inst.class.opcode == rspirv::spirv::Op::String);
     }
     let entry_fns: FxHashSet<u32> = spirv_module
         .entry_points
@@ -1096,7 +1098,7 @@ fn kernel_post_process(
             }
         });
         let spirv = spirv_module.assemble();
-        let spirv = if !debug_printf { 
+        let spirv = if !debug_printf {
             spirv_opt(&spirv, SpirvOptKind::Performance)?
         } else {
             spirv

--- a/krnlc/src/main.rs
+++ b/krnlc/src/main.rs
@@ -42,9 +42,10 @@ struct Cli {
     /// Check mode.
     #[arg(long = "check")]
     check: bool,
-    #[arg(long = "debug-printf", hide = true)]
+    /// Enable DebugPrintf
+    #[arg(long = "debug-printf")]
     debug_printf: bool,
-    /// Use verbose output.
+    /// Use verbose output
     #[arg(short = 'v', long = "verbose")]
     verbose: bool,
 }
@@ -628,7 +629,8 @@ crate-type = ["dylib"]
             .shader_panic_strategy(ShaderPanicStrategy::DebugPrintfThenExit {
                 print_inputs: true,
                 print_backtrace: true,
-            });
+            })
+            .spirv_metadata(SpirvMetadata::Full);
     }
     let capabilites = {
         use spirv_builder::Capability::*;
@@ -647,8 +649,11 @@ crate-type = ["dylib"]
     }
     let output = builder.build()?;
     let spirv_path = output.module.unwrap_single();
-    let spirv_module = rspirv::dr::load_bytes(std::fs::read(spirv_path)?)
+    let mut spirv_module = rspirv::dr::load_bytes(std::fs::read(spirv_path)?)
         .map_err(|e| Error::msg(e.to_string()))?;
+    if debug_printf {
+        spirv_module.debug_string_source.retain(|inst| inst.class.opcode == rspirv::spirv::Op::String);
+    }
     let entry_fns: FxHashSet<u32> = spirv_module
         .entry_points
         .iter()
@@ -664,6 +669,7 @@ crate-type = ["dylib"]
                 entry_point,
                 &spirv_module,
                 &entry_fns,
+                debug_printf,
             )
         })
         .collect()
@@ -773,6 +779,7 @@ fn kernel_post_process(
     entry_point: &rspirv::dr::Instruction,
     spirv_module: &rspirv::dr::Module,
     entry_fns: &FxHashSet<u32>,
+    debug_printf: bool,
 ) -> Result<KernelDesc> {
     use rspirv::{
         binary::Assemble,
@@ -1089,7 +1096,11 @@ fn kernel_post_process(
             }
         });
         let spirv = spirv_module.assemble();
-        let spirv = spirv_opt(&spirv, SpirvOptKind::Performance)?;
+        let spirv = if !debug_printf { 
+            spirv_opt(&spirv, SpirvOptKind::Performance)?
+        } else {
+            spirv
+        };
         {
             let path = kernels_dir.join(kernel_desc.name.replace("::", "/"));
             std::fs::create_dir_all(path.parent().unwrap())?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -32,12 +32,12 @@ One kernel can be queued while another is executing on that queue.
 use crate::kernel::{KernelDesc, KernelKey};
 use anyhow::Result;
 use serde::Deserialize;
-#[cfg(feature = "device")]
-use std::{ops::Range, sync::atomic::AtomicBool};
 use std::{
     fmt::{self, Debug},
     sync::Arc,
 };
+#[cfg(feature = "device")]
+use std::{ops::Range, sync::atomic::AtomicBool};
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "device"))]
 mod vulkan_engine;
@@ -597,11 +597,15 @@ impl RawKernel {
         groups: u32,
         buffers: &[DeviceBuffer],
         push_consts: Vec<u8>,
-        debug_printf_panic: Option<Arc<AtomicBool>>
+        debug_printf_panic: Option<Arc<AtomicBool>>,
     ) -> Result<()> {
         unsafe {
-            self.inner
-                .dispatch(groups, cast_device_buffers(buffers), push_consts, debug_printf_panic)
+            self.inner.dispatch(
+                groups,
+                cast_device_buffers(buffers),
+                push_consts,
+                debug_printf_panic,
+            )
         }
     }
     pub(crate) fn device(&self) -> RawDevice {

--- a/src/device.rs
+++ b/src/device.rs
@@ -33,7 +33,7 @@ use crate::kernel::{KernelDesc, KernelKey};
 use anyhow::Result;
 use serde::Deserialize;
 #[cfg(feature = "device")]
-use std::ops::Range;
+use std::{ops::Range, sync::atomic::AtomicBool};
 use std::{
     fmt::{self, Debug},
     sync::Arc,
@@ -184,6 +184,7 @@ trait DeviceEngineKernel: Sized {
         groups: u32,
         buffers: &[Arc<Self::DeviceBuffer>],
         push_consts: Vec<u8>,
+        debug_printf_panic: Option<Arc<AtomicBool>>,
     ) -> Result<()>;
     fn engine(&self) -> &Arc<Self::Engine>;
     fn desc(&self) -> &Arc<KernelDesc>;
@@ -339,7 +340,7 @@ impl RawDevice {
     pub(crate) fn info(&self) -> &Arc<DeviceInfo> {
         self.engine.info()
     }
-    fn wait(&self) -> Result<(), DeviceLost> {
+    pub(crate) fn wait(&self) -> Result<(), DeviceLost> {
         self.engine.wait()
     }
 }
@@ -596,10 +597,11 @@ impl RawKernel {
         groups: u32,
         buffers: &[DeviceBuffer],
         push_consts: Vec<u8>,
+        debug_printf_panic: Option<Arc<AtomicBool>>
     ) -> Result<()> {
         unsafe {
             self.inner
-                .dispatch(groups, cast_device_buffers(buffers), push_consts)
+                .dispatch(groups, cast_device_buffers(buffers), push_consts, debug_printf_panic)
         }
     }
     pub(crate) fn device(&self) -> RawDevice {

--- a/src/device.rs
+++ b/src/device.rs
@@ -29,7 +29,7 @@ One kernel can be queued while another is executing on that queue.
 */
 
 #[cfg(feature = "device")]
-use crate::kernel::{KernelDesc, KernelKey, SliceDesc};
+use crate::kernel::{KernelDesc, KernelKey};
 use anyhow::Result;
 use serde::Deserialize;
 #[cfg(feature = "device")]

--- a/src/device/vulkan_engine.rs
+++ b/src/device/vulkan_engine.rs
@@ -713,7 +713,8 @@ impl Frame {
             }
         }
         if let Some(debug_printf_panic) = debug_printf_panic {
-            self.debug_kernel_desc_panic.replace((kernel_desc.clone(), debug_printf_panic));
+            self.debug_kernel_desc_panic
+                .replace((kernel_desc.clone(), debug_printf_panic));
         }
     }
     unsafe fn finish(&mut self) {
@@ -793,7 +794,8 @@ impl Worker {
                 .unwrap()
                 .build()
                 .unwrap();
-            let _messenger = if let Some((kernel_desc, panicked)) = self.pending_frame.debug_kernel_desc_panic.take()
+            let _messenger = if let Some((kernel_desc, panicked)) =
+                self.pending_frame.debug_kernel_desc_panic.take()
             {
                 Some(
                     unsafe {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -565,7 +565,7 @@ fn strip_debug_printf(module: &mut rspirv::dr::Module) {
             true
         }
     });
-    module.debug_string_source.clear();
+    //module.debug_string_source.clear();
     if ext_insts.is_empty() {
         return;
     }
@@ -578,7 +578,7 @@ fn strip_debug_printf(module: &mut rspirv::dr::Module) {
                         return false;
                     }
                 }
-                true
+                true // !matches!(inst.class.opcode, Op::Line | Op::NoLine)
             })
         }
     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -436,7 +436,11 @@ use dry::macro_wrap;
 use rspirv::{binary::Assemble, dr::Operand};
 use std::{borrow::Cow, sync::Arc};
 #[cfg(feature = "device")]
-use std::{collections::HashMap, hash::Hash, sync::atomic::{AtomicBool, Ordering}};
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 #[cfg_attr(not(feature = "device"), allow(dead_code))]
 #[derive(Clone, Debug)]
@@ -1042,12 +1046,17 @@ pub mod __private {
                     bail!("Kernel `{kernel_name}` global_threads or groups not provided!");
                 };
                 let debug_printf_panic = if info.debug_printf() {
-                    Some(Arc::new(AtomicBool::default()))  
+                    Some(Arc::new(AtomicBool::default()))
                 } else {
                     None
                 };
                 unsafe {
-                    self.inner.dispatch(groups, &buffers, push_bytes, debug_printf_panic.clone())?;
+                    self.inner.dispatch(
+                        groups,
+                        &buffers,
+                        push_bytes,
+                        debug_printf_panic.clone(),
+                    )?;
                 }
                 if let Some(debug_printf_panic) = debug_printf_panic {
                     device.wait()?;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -528,7 +528,6 @@ impl KernelDesc {
                 }
             }
         }
-        module.debug_names.clear();
         if !debug_printf {
             strip_debug_printf(&mut module);
         }
@@ -547,6 +546,7 @@ impl KernelDesc {
 fn strip_debug_printf(module: &mut rspirv::dr::Module) {
     use rspirv::spirv::Op;
     use std::collections::HashSet;
+
     module.extensions.retain(|inst| {
         inst.operands.first().unwrap().unwrap_literal_string() != "SPV_KHR_non_semantic_info"
     });
@@ -565,10 +565,10 @@ fn strip_debug_printf(module: &mut rspirv::dr::Module) {
             true
         }
     });
-    //module.debug_string_source.clear();
     if ext_insts.is_empty() {
         return;
     }
+    module.debug_string_source.clear();
     for func in module.functions.iter_mut() {
         for block in func.blocks.iter_mut() {
             block.instructions.retain(|inst| {
@@ -578,7 +578,7 @@ fn strip_debug_printf(module: &mut rspirv::dr::Module) {
                         return false;
                     }
                 }
-                true // !matches!(inst.class.opcode, Op::Line | Op::NoLine)
+                !matches!(inst.class.opcode, Op::Line | Op::NoLine)
             })
         }
     }


### PR DESCRIPTION
Makes visible --debug-printf flag in krnlc. Detects when the validation layer is active. When active, kernels will block on completion, and return an error on panic. Also adds additional info, including device index and kernel name to messages that are printed to stderr.  