### PR TITLE
chore(cargo): set `repository` field in main `krnlc` crate

### DIFF
--- a/krnlc/Cargo.toml
+++ b/krnlc/Cargo.toml
@@ -9,6 +9,7 @@ description = "Kernel compiler for krnl."
 documentation = "https://docs.rs/krnl"
 readme = "../README.md"
 homepage = "https://github.com/charles-r-earp/krnl"
+repository = "https://github.com/charles-r-earp/krnl"
 license = "MIT OR Apache-2.0"
 publish = false
 autoexamples = false


### PR DESCRIPTION
Set [repository](https://rust-digger.code-maven.com/about-repository) key for correctly pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

This change only affects the main `krnlc` crate and not any of the ones within the workspace, as they already inherit repository.